### PR TITLE
Update functions for python 3

### DIFF
--- a/referral_candy/referral_candy.py
+++ b/referral_candy/referral_candy.py
@@ -19,8 +19,8 @@ class ReferralCandy:
         return params
 
     def _signature(self, params):
-        collected_params = ''.join(('%s=%s' % (k,v)) for k, v in sorted(params.iteritems()))
-        return hashlib.md5(self.secret_key + collected_params).hexdigest()
+        collected_params = ''.join(('%s=%s' % (k,v)) for k, v in sorted(params.items()))
+        return hashlib.md5((self.secret_key + collected_params).encode()).hexdigest()
 
 def define_endpoint_fn(verb, ep):
     def endpoint_fn(self, params=None):
@@ -31,6 +31,6 @@ def define_endpoint_fn(verb, ep):
                                params=self._add_signature_to(params))
     setattr(ReferralCandy, ep, endpoint_fn)
 
-for verb, endpoints in _API_METHODS.iteritems():
+for verb, endpoints in _API_METHODS.items():
     for ep in endpoints:
         define_endpoint_fn(verb, ep)


### PR DESCRIPTION
To adopt the implementation for python 3, updates/changes listed as below:

- Update `iteritems()` to `items()`: In Python 3.x, .items() is now an itemview object which does the thing dict.iteritems did in python 2.x and even improved it a bit.
- Add `encode()` for hashlib.md5 to convert the string into bytes to be acceptable by the hash function.
